### PR TITLE
update README with more detail

### DIFF
--- a/LFR/README.md
+++ b/LFR/README.md
@@ -16,7 +16,8 @@ Open the Visual Studio solution at `/LFR/vs/LFR.sln` and compile it. Compilation
 
 ### Linux (e.g. a Raspberry Pi) building: 
 Install [GLFW](https://www.glfw.org/) and compile [Assimp](https://www.assimp.org/) first. 
-To build the module, make [LFR](/LFR) the current directory and run `make `.
+To build the module, make [LFR](/LFR) the current directory and run `make `. 
+After that, change the dir to LFR/bin and run './main'. Note that you must go to the subdir of the LFR first before you run the 'main' file.
 
 
 ## Detailed usage


### PR DESCRIPTION
Current README  is prone to tell people using the LFR as the CWD, however, when execute the 'main' program, must use the subdir as the CWD. This is because the code use  relative path '../shader/' to file the shader files. When I tried to build the code, I had faced the problem that 'SHADER ERROR' and puzzled me for a long time. To avoid the similar situations, I recommend adding some detail about how to execute the './main' after building successfully.