### PR TITLE
AOS/LFR(fix): illegal hardware instruction

### DIFF
--- a/AOS for Own Projects/LFR/include/util/window.h
+++ b/AOS for Own Projects/LFR/include/util/window.h
@@ -123,6 +123,7 @@ int InitWindowAndGUI(int &width, int &height, const char* appname = "OpenGL")
         ImGui_ImplOpenGL3_Init(glsl_version);
 
         gui = true;
+        return 0;
     }
     else
         return -1;


### PR DESCRIPTION
When building the LFR project under linux it crashes during runtime because of a missing return leading to an illegal hardware instruction.